### PR TITLE
Release v0.6.0 & 重构说明

### DIFF
--- a/Flandre.sln
+++ b/Flandre.sln
@@ -2,8 +2,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Flandre.Core", "src\Flandre.Core\Flandre.Core.csproj", "{347EE5CE-CAB6-4FFA-AAF1-D7AA7BC6AFF7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Flandre.ExampleBot", "src\Flandre.ExampleBot\Flandre.ExampleBot.csproj", "{49D31127-B126-4734-B6E4-C1A6A6A41A5E}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Flandre.Adapters.Konata", "src\Flandre.Adapters.Konata\Flandre.Adapters.Konata.csproj", "{723E8DD2-55F1-4095-93D7-E6AD600A63EE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Flandre.Core.Tests", "tests\Flandre.Core.Tests\Flandre.Core.Tests.csproj", "{22726A9B-8E54-4513-AB04-61B4A34DDC2A}"
@@ -22,10 +20,6 @@ Global
 		{347EE5CE-CAB6-4FFA-AAF1-D7AA7BC6AFF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{347EE5CE-CAB6-4FFA-AAF1-D7AA7BC6AFF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{347EE5CE-CAB6-4FFA-AAF1-D7AA7BC6AFF7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{49D31127-B126-4734-B6E4-C1A6A6A41A5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{49D31127-B126-4734-B6E4-C1A6A6A41A5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{49D31127-B126-4734-B6E4-C1A6A6A41A5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{49D31127-B126-4734-B6E4-C1A6A6A41A5E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{723E8DD2-55F1-4095-93D7-E6AD600A63EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{723E8DD2-55F1-4095-93D7-E6AD600A63EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{723E8DD2-55F1-4095-93D7-E6AD600A63EE}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/Flandre.Adapters.Konata/KonataBot.cs
+++ b/src/Flandre.Adapters.Konata/KonataBot.cs
@@ -23,6 +23,9 @@ public sealed class KonataBot : FlandreBot
     /// </summary>
     public override string Platform => _config.PlatformOverride ?? "konata";
 
+    /// <inheritdoc />
+    public override string SelfId { get; }
+
     /// <summary>
     /// Konata 内部 bot
     /// </summary>
@@ -51,6 +54,10 @@ public sealed class KonataBot : FlandreBot
         _logger = logger;
         Internal = BotFather.Create(config.Konata, config.Device, config.KeyStore);
         _config = config;
+
+        SelfId = string.IsNullOrWhiteSpace(_config.SelfId)
+            ? Internal.Uin.ToString()
+            : _config.SelfId;
 
         Internal.OnFriendMessage += InnerOnFriendMessage;
         Internal.OnGroupMessage += InnerOnGroupMessage;

--- a/src/Flandre.Adapters.Mock/MockBot.cs
+++ b/src/Flandre.Adapters.Mock/MockBot.cs
@@ -15,6 +15,8 @@ public class MockBot : Bot
     /// </summary>
     public override string Platform => "mock";
 
+    public override string SelfId => _selfId;
+
     private readonly Logger _logger;
 
     private readonly string _selfId = Guid.NewGuid().ToString();

--- a/src/Flandre.Adapters.OneBot/CqCodeParser.cs
+++ b/src/Flandre.Adapters.OneBot/CqCodeParser.cs
@@ -30,6 +30,7 @@ public static class CqCodeParser
                     "face" => ParseFace(sections[1..]),
                     "record" => ParseRecord(sections[1..]),
                     "image" => ParseImage(sections[1..]),
+                    "at" => ParseAt(sections[1..]),
                     _ => new TextSegment(code)
                 });
             }
@@ -144,5 +145,10 @@ public static class CqCodeParser
         }
 
         return segment;
+    }
+    
+    private static AtSegment ParseAt(string[] data)
+    {
+        return new AtSegment(data[0][3..]); // qq=xxx
     }
 }

--- a/src/Flandre.Adapters.OneBot/GuildBot.cs
+++ b/src/Flandre.Adapters.OneBot/GuildBot.cs
@@ -16,6 +16,11 @@ public class OneBotGuildBot : Bot
     /// </summary>
     public override string Platform => "qqguild";
 
+    public override string SelfId => _selfId;
+
+    private string _selfId = "";
+    private bool _isSelfIdSet;
+
     public OneBotGuildInternalBot Internal { get; }
 
     private readonly OneBotBot _mainBot;
@@ -35,6 +40,12 @@ public class OneBotGuildBot : Bot
 
     internal void InvokeMessageEvent(OneBotApiGuildMessageEvent e)
     {
+        if (!_isSelfIdSet)
+        {
+            _selfId = e.SelfId.ToString();
+            _isSelfIdSet = true;
+        }
+
         OnMessageReceived?.Invoke(this, new BotMessageReceivedEvent(new Message
         {
             Time = DateTimeOffset.FromUnixTimeSeconds(e.Time).DateTime,

--- a/src/Flandre.Adapters.OneBot/OneBotBot.cs
+++ b/src/Flandre.Adapters.OneBot/OneBotBot.cs
@@ -14,6 +14,9 @@ public abstract class OneBotBot : Bot
     /// </summary>
     public override string Platform => "onebot";
 
+    /// <inheritdoc />
+    public override string SelfId { get; }
+
     internal readonly OneBotGuildBot GuildBot;
     internal readonly Logger Logger;
 
@@ -24,8 +27,9 @@ public abstract class OneBotBot : Bot
 
     protected override Logger GetLogger() => Logger;
 
-    internal OneBotBot(Logger logger)
+    internal OneBotBot(string selfId, Logger logger)
     {
+        SelfId = selfId;
         Internal = new OneBotInternalBot(this);
         GuildBot = new OneBotGuildBot(this);
         Logger = logger;

--- a/src/Flandre.Adapters.OneBot/WebSocketBot.cs
+++ b/src/Flandre.Adapters.OneBot/WebSocketBot.cs
@@ -25,7 +25,7 @@ public class OneBotWebSocketBot : OneBotBot
     public override event BotEventHandler<BotGuildJoinRequestedEvent>? OnGuildJoinRequested;
     public override event BotEventHandler<BotFriendRequestedEvent>? OnFriendRequested;
 
-    internal OneBotWebSocketBot(OneBotBotConfig config, Logger logger) : base(logger)
+    internal OneBotWebSocketBot(OneBotBotConfig config, Logger logger) : base(config.SelfId, logger)
     {
         _config = config;
 

--- a/src/Flandre.Core/Attributes/CommandAttribute.cs
+++ b/src/Flandre.Core/Attributes/CommandAttribute.cs
@@ -58,8 +58,7 @@ public class CommandAttribute : Attribute
             }
 
             Parameters.Add(info);
-
-            FlandreApp.Logger.Debug(Parameters.Count.ToString());
+            
             parser.SkipSpaces();
         }
     }

--- a/src/Flandre.Core/Common/Bot.cs
+++ b/src/Flandre.Core/Common/Bot.cs
@@ -16,6 +16,11 @@ public abstract class Bot
     public abstract string Platform { get; }
 
     /// <summary>
+    /// Bot 自身 ID
+    /// </summary>
+    public abstract string SelfId { get; }
+
+    /// <summary>
     /// 获取 Logger
     /// </summary>
     protected abstract Logger GetLogger();

--- a/src/Flandre.Core/Common/Command.cs
+++ b/src/Flandre.Core/Common/Command.cs
@@ -59,9 +59,8 @@ public class Command
         {
             var peek = parser.SkipSpaces().Peek(' ');
 
-            if (peek.StartsWith("--"))
+            if (peek.StartsWith("--")) // option (full)
             {
-                // option (full)
                 var optName = parser.Read(' ').TrimStart('-');
                 var optNo = false;
 
@@ -96,9 +95,8 @@ public class Command
                         break;
                 }
             }
-            else if (peek.StartsWith('-'))
+            else if (peek.StartsWith('-')) // option (short)
             {
-                // option (short)
                 var opts = parser.Read(' ').TrimStart('-');
 
                 parser.SkipSpaces();
@@ -128,25 +126,31 @@ public class Command
                     }
                 }
             }
-            else
+            else // argument
             {
-                // argument
                 if (argIndex >= CommandInfo.Parameters.Count)
                     return (args, "参数过多，请检查指令格式。");
 
                 var param = CommandInfo.Parameters[argIndex];
 
-                if (param.Type == "string")
+                switch (param.Type)
                 {
-                    args.Arguments.ArgumentList.Add(
-                        new KeyValuePair<string, object>(param.Name, parser.ReadQuoted()));
-                }
-                else
-                {
-                    if (CommandUtils.TryParseType(parser.Read(' '),
-                            param.Type, out var result, false))
-                        args.Arguments.ArgumentList.Add(new KeyValuePair<string, object>(param.Name, result));
-                    else return (args, $"参数 {param.Name} 类型错误，应为 {param.Type}。");
+                    case "string":
+                        args.Arguments.ArgumentList.Add(
+                            new KeyValuePair<string, object>(param.Name, parser.ReadQuoted()));
+                        break;
+                    
+                    case "text":
+                        args.Arguments.ArgumentList.Add(
+                            new KeyValuePair<string, object>(param.Name, parser.ReadToEnd()));
+                        break;
+
+                    default:
+                        if (CommandUtils.TryParseType(parser.Read(' '),
+                                param.Type, out var result, false))
+                            args.Arguments.ArgumentList.Add(new KeyValuePair<string, object>(param.Name, result));
+                        else return (args, $"参数 {param.Name} 类型错误，应为 {param.Type}。");
+                        break;
                 }
 
                 providedArgs.Add(param.Name);

--- a/src/Flandre.Core/Common/Context.cs
+++ b/src/Flandre.Core/Common/Context.cs
@@ -30,4 +30,9 @@ public class Context
     /// Bot 所在平台，等同于 Bot.Platform。
     /// </summary>
     public string Platform => Bot.Platform;
+
+    /// <summary>
+    /// Bot 自身 ID，等同于 Bot.SelfId。
+    /// </summary>
+    public string SelfId => Bot.SelfId;
 }

--- a/src/Flandre.Core/Extensions/AppExtensions.cs
+++ b/src/Flandre.Core/Extensions/AppExtensions.cs
@@ -14,7 +14,7 @@ public static class AppExtensions
     /// <param name="botId">Bot.SelfId</param>
     public static void SetGuildAssignee(this FlandreApp app, string platform, string guildId, string botId)
     {
-        app.GuildAssignees.TryAdd($"{platform}:{guildId}", botId);
+        app.GuildAssignees.AddOrUpdate($"{platform}:{guildId}", botId, (_, _) => botId);
     }
 
     /// <summary>

--- a/src/Flandre.Core/Extensions/AppExtensions.cs
+++ b/src/Flandre.Core/Extensions/AppExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace Flandre.Core.Extensions;
+
+/// <summary>
+/// <see cref="FlandreApp" /> 的扩展方法
+/// </summary>
+public static class AppExtensions
+{
+    /// <summary>
+    /// 设置群组代理 Bot（主 Bot）
+    /// </summary>
+    /// <param name="app">FlandreApp 实例</param>
+    /// <param name="platform">平台</param>
+    /// <param name="guildId">群组 ID</param>
+    /// <param name="botId">Bot.SelfId</param>
+    public static void SetGuildAssignee(this FlandreApp app, string platform, string guildId, string botId)
+    {
+        app.GuildAssignees.TryAdd($"{platform}:{guildId}", botId);
+    }
+
+    /// <summary>
+    /// 检查群组是否已被代理（已设置主 bot）
+    /// </summary>
+    /// <param name="app">FlandreApp 实例</param>
+    /// <param name="platform">平台</param>
+    /// <param name="botId">Bot.SelfId</param>
+    public static bool IsGuildAssigned(this FlandreApp app, string platform, string botId)
+    {
+        return app.GuildAssignees.ContainsKey($"{platform}:{botId}");
+    }
+}

--- a/src/Flandre.Core/Extensions/ContextExtensions.cs
+++ b/src/Flandre.Core/Extensions/ContextExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Flandre.Core.Messaging;
+
+namespace Flandre.Core.Extensions;
+
+/// <summary>
+/// 上下文扩展方法
+/// </summary>
+public static class ContextExtensions
+{
+    /// <summary>
+    /// 将 Bot 设置为群组主 Bot
+    /// </summary>
+    /// <param name="ctx">消息上下文</param>
+    public static void SetBotAsGuildAssignee(this MessageContext ctx)
+    {
+        if (ctx.GuildId is null) return;
+        ctx.App.SetGuildAssignee(ctx.Platform, ctx.GuildId, ctx.SelfId);
+    }
+}

--- a/src/Flandre.Core/Flandre.Core.csproj
+++ b/src/Flandre.Core/Flandre.Core.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Title>Flandre.Core</Title>
         <Product>$(Title)</Product>
-        <PackageVersion>0.5.0</PackageVersion>
+        <PackageVersion>0.6.0</PackageVersion>
         <Version>$(PackageVersion)</Version>
         <Authors>b1acksoil</Authors>
         <Description>跨平台，低耦合的聊天机器人框架，一次编写，多处运行。</Description>

--- a/src/Flandre.Core/FlandreApp.cs
+++ b/src/Flandre.Core/FlandreApp.cs
@@ -300,7 +300,7 @@ public partial class FlandreApp
         }
 
         var commandStr = ctx.Message.GetText().Trim();
-        if (commandStr == Config.CommandPrefix || !commandStr.StartsWith(Config.CommandPrefix))
+        if (commandStr == Config.CommandPrefix)
             return null;
 
         var parser = new StringParser(commandStr);
@@ -310,6 +310,7 @@ public partial class FlandreApp
         if (ShortcutMap.TryGetValue(root, out var command))
             return ParseAndInvoke(command, parser);
 
+        if (!root.StartsWith(Config.CommandPrefix)) return null;
         root = root.TrimStart(Config.CommandPrefix);
         parser.SkipSpaces();
 

--- a/src/Flandre.Core/FlandreApp.cs
+++ b/src/Flandre.Core/FlandreApp.cs
@@ -310,7 +310,9 @@ public partial class FlandreApp
         if (ShortcutMap.TryGetValue(root, out var command))
             return ParseAndInvoke(command, parser);
 
-        if (!root.StartsWith(Config.CommandPrefix)) return null;
+        if (!string.IsNullOrWhiteSpace(Config.CommandPrefix)
+            && !root.StartsWith(Config.CommandPrefix))
+            return null;
         root = root.TrimStart(Config.CommandPrefix);
         parser.SkipSpaces();
 

--- a/src/Flandre.Core/Messaging/MessageContent.cs
+++ b/src/Flandre.Core/Messaging/MessageContent.cs
@@ -8,7 +8,7 @@ namespace Flandre.Core.Messaging;
 /// </summary>
 public class MessageContent : IEnumerable<MessageSegment>
 {
-    private readonly IEnumerable<MessageSegment> _segments;
+    internal IEnumerable<MessageSegment> Segments { get; }
 
     /// <summary>
     /// 使用消息段构造消息内容
@@ -16,7 +16,7 @@ public class MessageContent : IEnumerable<MessageSegment>
     /// <param name="segments"></param>
     public MessageContent(IEnumerable<MessageSegment> segments)
     {
-        _segments = segments;
+        Segments = segments;
     }
 
     /// <summary>
@@ -25,7 +25,7 @@ public class MessageContent : IEnumerable<MessageSegment>
     /// <typeparam name="TSegment">消息段类型</typeparam>
     public TSegment? GetSegment<TSegment>() where TSegment : MessageSegment
     {
-        return (TSegment?)_segments.FirstOrDefault(segment => segment is TSegment);
+        return (TSegment?)Segments.FirstOrDefault(segment => segment is TSegment);
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ public class MessageContent : IEnumerable<MessageSegment>
     /// <typeparam name="TSegment">消息段类型</typeparam>
     public IEnumerable<TSegment> GetSegments<TSegment>() where TSegment : MessageSegment
     {
-        return _segments.Where(segment => segment is TSegment).Cast<TSegment>();
+        return Segments.Where(segment => segment is TSegment).Cast<TSegment>();
     }
 
     /// <summary>
@@ -83,7 +83,7 @@ public class MessageContent : IEnumerable<MessageSegment>
     /// <returns></returns>
     public IEnumerator<MessageSegment> GetEnumerator()
     {
-        return _segments.GetEnumerator();
+        return Segments.GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()

--- a/src/Flandre.Core/Middlewares.cs
+++ b/src/Flandre.Core/Middlewares.cs
@@ -11,8 +11,10 @@ public partial class FlandreApp
         if (ctx.SelfId == segment?.UserId)
             next();
         // 如果没找到群组的 assignee
-        else if (!GuildAssignees.TryGetValue($"{ctx.Platform}:{ctx.GuildId}", out var assignee)
-             && assignee == ctx.SelfId) // 找到了，而且是自己
+        else if (!GuildAssignees.TryGetValue($"{ctx.Platform}:{ctx.GuildId}", out var assignee))
+            next();
+        // 如果找到了群组的 assignee，且是自己
+        else if (ctx.SelfId == assignee)
             next();
     }
     

--- a/src/Flandre.Core/Middlewares.cs
+++ b/src/Flandre.Core/Middlewares.cs
@@ -7,9 +7,12 @@ public partial class FlandreApp
 {
     internal void CheckAssigneeMiddleware(MessageContext ctx, Action next)
     {
-        var segment = ctx.Message.Content.GetSegment<AtSegment>();
-        if (ctx.SelfId == segment?.UserId)
-            next();
+        var segment = ctx.Message.Content.Segments.FirstOrDefault();
+        if (segment is AtSegment ats)
+        {
+            if (ats.UserId == ctx.SelfId)
+                next();
+        }
         // 如果没找到群组的 assignee
         else if (!GuildAssignees.TryGetValue($"{ctx.Platform}:{ctx.GuildId}", out var assignee))
             next();

--- a/src/Flandre.Core/Middlewares.cs
+++ b/src/Flandre.Core/Middlewares.cs
@@ -1,0 +1,34 @@
+﻿using Flandre.Core.Messaging;
+using Flandre.Core.Messaging.Segments;
+
+namespace Flandre.Core;
+
+public partial class FlandreApp
+{
+    internal void CheckAssigneeMiddleware(MessageContext ctx, Action next)
+    {
+        var segment = ctx.Message.Content.GetSegment<AtSegment>();
+        if (ctx.SelfId == segment?.UserId)
+            next();
+
+        // 如果没找到群组的 assignee
+        if (!GuildAssignees.TryGetValue($"{ctx.Platform}:{ctx.GuildId}", out var assignee)
+            && assignee == ctx.SelfId) // 找到了，而且是自己
+            next();
+    }
+
+    internal void PluginMessageReceivedMiddleware(MessageContext ctx, Action next)
+    {
+        foreach (var plugin in Plugins)
+            plugin.OnMessageReceived(ctx);
+        next();
+    }
+
+    internal void ParseCommandMiddleware(MessageContext ctx, Action next)
+    {
+        var content = ParseCommand(ctx);
+        if (content is not null)
+            ctx.Bot.SendMessage(ctx.Message, content);
+        next();
+    }
+}

--- a/src/Flandre.Core/Middlewares.cs
+++ b/src/Flandre.Core/Middlewares.cs
@@ -10,20 +10,19 @@ public partial class FlandreApp
         var segment = ctx.Message.Content.GetSegment<AtSegment>();
         if (ctx.SelfId == segment?.UserId)
             next();
-
         // 如果没找到群组的 assignee
-        if (!GuildAssignees.TryGetValue($"{ctx.Platform}:{ctx.GuildId}", out var assignee)
-            && assignee == ctx.SelfId) // 找到了，而且是自己
+        else if (!GuildAssignees.TryGetValue($"{ctx.Platform}:{ctx.GuildId}", out var assignee)
+             && assignee == ctx.SelfId) // 找到了，而且是自己
             next();
     }
-
+    
     internal void PluginMessageReceivedMiddleware(MessageContext ctx, Action next)
     {
         foreach (var plugin in Plugins)
             plugin.OnMessageReceived(ctx);
         next();
     }
-
+    
     internal void ParseCommandMiddleware(MessageContext ctx, Action next)
     {
         var content = ParseCommand(ctx);

--- a/tests/Flandre.Core.Tests/FlandreAppTests.cs
+++ b/tests/Flandre.Core.Tests/FlandreAppTests.cs
@@ -1,6 +1,8 @@
 ﻿using Flandre.Adapters.Mock;
 using Flandre.Core.Utils;
 
+// ReSharper disable StringLiteralTypo
+
 namespace Flandre.Core.Tests;
 
 public class FlandreAppTests
@@ -31,6 +33,10 @@ public class FlandreAppTests
 
             content = friendClient.SendForReply("test1 -bo 111.444 --no-trueopt false").Result;
             Assert.Equal("arg1: False opt: 111.444 b: True t: False",
+                content?.GetText());
+            
+            content = friendClient.SendForReply("test2  some text aaa   bbb   ").Result;
+            Assert.Equal("some text aaa   bbb",
                 content?.GetText());
 
             app.Stop();

--- a/tests/Flandre.Core.Tests/TestPlugin.cs
+++ b/tests/Flandre.Core.Tests/TestPlugin.cs
@@ -29,6 +29,13 @@ public class TestPlugin : Plugin
         var trueOpt = args.GetOption<bool>("trueopt");
         return $"arg1: {arg1} opt: {opt} b: {boolOpt} t: {trueOpt}";
     }
+    
+    [Command("test2 <arg1:text>")]
+    public static MessageContent OnTest2(MessageContext _, ParsedArgs args)
+    {
+        var arg1 = args.GetArgument<string>("arg1");
+        return arg1;
+    }
 
     [Command("sub.test")]
     [Alias("sssuuubbb")]


### PR DESCRIPTION
Flandre 在经过一系列的迭代，已经发展到了 v0.6.0 版本。但项目的架构方面目前有一些问题：

- `Flandre.Core` 名不符实，虽名为 Core，但并没有体现出“核心”该有的小体量，而是大包大揽，囊括了指令、插件等种种功能。这导致可扩展性堪忧，同时也难以作为小模块嵌入已有项目中。
- Flandre 目前仍未实现一些现代框架的特性，例如依赖注入等。

目前打算拆分现在的 `Flandre.Core` 包，转换为两个分离的组件：`Flandre.Core` 和 `Flandre.Framework`。

- `Flandre.Core` 将仅包含：适配器 (Adapter) 部分、机器人 (Bot) 部分、消息相关 (MessageSegment...)、模型相关 (User, Guild...) 等通用组件。
- `Flandre.Framework` 将包含：与 Core 模块交互；完整的指令、插件系统；多机器人实例管理；依赖注入；统一化日志管理等。